### PR TITLE
#22: Add migrations verifying in CI

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -47,10 +47,22 @@ jobs:
         - name: Lint
           run: revive -config ./config/revive.toml
 
+  verify_migrations:
+      name: "Verifying migrations"
+      runs-on: ubuntu-latest
+
+      steps:
+        - name: Checkout repo
+          uses: actions/checkout@v3
+
+        - name: Testing
+          run: docker-compose -f ./docker/test/docker-compose.yml up --build --abort-on-container-exit --exit-code-from migrations_test
+          shell: bash
+
   test:
     name: "Testing"
     runs-on: ubuntu-latest
-    needs: [build, lint]
+    needs: [build, lint, verify_migrations]
 
     steps:
       - name: Checkout repo

--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,10 @@ build:
 test:
 	go test -mod=vendor ./...
 
+
+verify_migrations:
+	docker-compose -f ./docker/test/docker-compose.yml up --abort-on-container-exit --build --exit-code-from migrations_test
+	docker-compose -f ./docker/test/docker-compose.yml down -v --rmi "local"
+
 clean:
 	rm -rf *.out *.exe *.html *.csv

--- a/db/000001_database-init.up.sql
+++ b/db/000001_database-init.up.sql
@@ -1,13 +1,13 @@
 create type session_state_t as enum ('active', 'closed');
 
-create table users (
-    id bigserial not null,
-    tg_id bigint not null,
-    username text not null,
-    created_at date default current_timestamp not null,
-    requisites text not null,
-    primary key (id)
-);
+-- create table users (
+--     id bigserial not null,
+--     tg_id bigint not null,
+--     username text not null,
+--     created_at date default current_timestamp not null,
+--     requisites text not null,
+--     primary key (id)
+-- );
 
 create table sessions (
     uuid uuid not null,

--- a/db/000001_database-init.up.sql
+++ b/db/000001_database-init.up.sql
@@ -1,13 +1,13 @@
 create type session_state_t as enum ('active', 'closed');
 
--- create table users (
---     id bigserial not null,
---     tg_id bigint not null,
---     username text not null,
---     created_at date default current_timestamp not null,
---     requisites text not null,
---     primary key (id)
--- );
+create table users (
+    id bigserial not null,
+    tg_id bigint not null,
+    username text not null,
+    created_at date default current_timestamp not null,
+    requisites text not null,
+    primary key (id)
+);
 
 create table sessions (
     uuid uuid not null,

--- a/docker/base/Dockerfile.migrations
+++ b/docker/base/Dockerfile.migrations
@@ -1,7 +1,6 @@
 FROM migrate/migrate
 
-ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait /wait.sh
 COPY ./db /db
 
 ENTRYPOINT []
-CMD chmod +x /wait.sh && /wait.sh && migrate -path /db -database postgres://$USER:$PSWD@$HOST/$DB?sslmode=disable up
+CMD migrate -path /db -database postgres://$USER:$PSWD@$HOST/$DB?sslmode=disable up

--- a/docker/local/docker-compose.yml
+++ b/docker/local/docker-compose.yml
@@ -6,13 +6,15 @@ services:
     build:
       context: ../..
       dockerfile: ./docker/base/Dockerfile
-    depends_on:
-      - pg
-      - migrations
     restart: unless-stopped
     command:
       - "-t"
       - ${BOT_TOKEN}
+    depends_on:
+      pg:
+        condition: service_healthy
+      migrations:
+        condition: service_completed_successfully
 
   pg:
     container_name: pg
@@ -29,6 +31,11 @@ services:
     volumes:
       - pg_data_volume:/data/lib/postgresql/data
     restart: unless-stopped
+    healthcheck:
+      test: pg_isready --dbname=$DB_NAME --username=$DB_USER
+      interval: 5s
+      timeout: 5s
+      retries: 10
 
   migrations:
     build:
@@ -36,13 +43,13 @@ services:
       dockerfile: ./docker/base/Dockerfile.migrations
     container_name: migrations
     depends_on:
-      - pg
+      pg:
+        condition: service_healthy
     environment:
       USER: ${DB_USER}
       PSWD: ${DB_PSWD}
       HOST: pg:5432
       DB: ${DB_NAME}
-      WAIT_HOSTS: pg:5432
 
 volumes:
   pg_data_volume:

--- a/docker/prod/docker-compose.yml
+++ b/docker/prod/docker-compose.yml
@@ -4,13 +4,16 @@ services:
   app:
     image: ivaaahn/collector-server:${APP_VERSION}
     container_name: app
-    depends_on:
-      - pg
-      - migrations
     restart: unless-stopped
     command:
       - "-t"
       - ${BOT_TOKEN}
+    depends_on:
+      pg:
+        condition: service_healthy
+      migrations:
+        condition: service_completed_successfully
+
 
   pg:
     image: postgres:14-alpine
@@ -27,6 +30,12 @@ services:
     volumes:
       - pg_data_volume:/data/lib/postgresql/data
     restart: unless-stopped
+    healthcheck:
+      test: pg_isready --dbname=$DB_NAME --username=$DB_USER
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
 
   migrations:
     image: ivaaahn/collector-migrations:${APP_VERSION}
@@ -38,7 +47,6 @@ services:
       PSWD: ${DB_PSWD}
       HOST: pg:5432
       DB: ${DB_NAME}
-      WAIT_HOSTS: pg:5432
 
 volumes:
   pg_data_volume:

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -1,10 +1,7 @@
 FROM migrate/migrate
 
-ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait /wait.sh
 COPY ./db /db
 
 ENTRYPOINT []
-CMD chmod +x /wait.sh \
-        && /wait.sh \
-        && migrate -path '/db' -database postgres://$USER:$PSWD@$HOST/$DB?sslmode=disable up \
-        && echo "y" | migrate -path '/db' -database postgres://$USER:$PSWD@$HOST/$DB?sslmode=disable down
+CMD migrate -path '/db' -database postgres://$USER:$PSWD@$HOST/$DB?sslmode=disable up \
+    && echo "y" | migrate -path '/db' -database postgres://$USER:$PSWD@$HOST/$DB?sslmode=disable down

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -1,0 +1,10 @@
+FROM migrate/migrate
+
+ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait /wait.sh
+COPY ./db /db
+
+ENTRYPOINT []
+CMD chmod +x /wait.sh \
+        && /wait.sh \
+        && migrate -path '/db' -database postgres://$USER:$PSWD@$HOST/$DB?sslmode=disable up \
+        && echo "y" | migrate -path '/db' -database postgres://$USER:$PSWD@$HOST/$DB?sslmode=disable down

--- a/docker/test/docker-compose.yml
+++ b/docker/test/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "3.9"
+
+services:
+  pg_test:
+    image: postgres:14-alpine
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: test
+      POSTGRES_PASSWORD: test
+      POSTGRES_DB: test
+
+  migrations_test:
+    build:
+      context: ../..
+      dockerfile: ./docker/test/Dockerfile
+    depends_on:
+      - pg_test
+    environment:
+      USER: test
+      PSWD: test
+      HOST: pg_test:5432
+      DB: test
+      WAIT_HOSTS: pg_test:5432

--- a/docker/test/docker-compose.yml
+++ b/docker/test/docker-compose.yml
@@ -9,16 +9,21 @@ services:
       POSTGRES_USER: test
       POSTGRES_PASSWORD: test
       POSTGRES_DB: test
+    healthcheck:
+      test: pg_isready --dbname=test --username=test
+      interval: 5s
+      timeout: 5s
+      retries: 10
 
   migrations_test:
     build:
       context: ../..
       dockerfile: ./docker/test/Dockerfile
-    depends_on:
-      - pg_test
     environment:
       USER: test
       PSWD: test
       HOST: pg_test:5432
       DB: test
-      WAIT_HOSTS: pg_test:5432
+    depends_on:
+      pg_test:
+        condition: service_healthy


### PR DESCRIPTION
## Добавлено:
- джоба в пайплайне для проверки миграций
- в Makefile появился verify_migrations, которым можно пользоваться перед пушем

## Дополнительно
- wait.sh заменен на healthcheck
